### PR TITLE
Changed data type to match test name

### DIFF
--- a/src/number.rs
+++ b/src/number.rs
@@ -250,14 +250,28 @@ mod tests {
 
     #[test]
     fn can_generate_signed_number_less_than() {
-        let to: u32 = 1000;
+        let to: i32 = 1000;
+        let actual = some_number_less_than(to);
+        assert!(actual < to);
+    }
+
+    #[test]
+    fn can_generate_unsigned_number_less_than() {
+        let to: usize = 1000;
         let actual = some_number_less_than(to);
         assert!(actual < to);
     }
 
     #[test]
     fn can_generate_signed_number_greater_than() {
-        let from: u32 = 1000;
+        let from: i32 = 1000;
+        let actual = some_number_greater_than(from);
+        assert!(actual > from);
+    }
+
+    #[test]
+    fn can_generate_unsigned_number_greater_than() {
+        let from: usize = 1000;
         let actual = some_number_greater_than(from);
         assert!(actual > from);
     }


### PR DESCRIPTION
Two tests were designed to test signed numbers, but the test number type was
unsigned. The corresponding unsigned version of tests is added.